### PR TITLE
refactor: separate search ui fxn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -887,7 +887,7 @@ dependencies = [
 
 [[package]]
 name = "search_blame"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "assert_cmd",
  "assert_fs",

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -3,7 +3,7 @@ use std::process;
 use clap::Parser;
 use console::{style, Emoji};
 use git2::Repository;
-use search_blame::{blame, search, Cli};
+use search_blame::{blame, search_with_ui, Cli};
 fn main() {
     let cli = Cli::parse();
     // get git root: if root is not provided then files is git root
@@ -19,7 +19,7 @@ fn main() {
         Ok(repo) => repo,
         Err(_) => panic!("Could not open the repository"),
     };
-    let mut files = search(cli.text, files);
+    let mut files = search_with_ui(cli.text, files);
     if files.is_empty() {
         println!("{}", style("Text not found in the path").red());
         process::exit(1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 pub use self::{
     cli::Cli,
     git::{blame, BlameFileResult},
-    search::{search, FileResult, SearchResult},
+    search::{search, search_with_custom_ui, search_with_ui, SearchResult},
 };
 mod cli;
 mod git;


### PR DESCRIPTION
Let us separate ui from search functionality. This may help when we just want the results e.g. in a library.